### PR TITLE
Remove unnecessary constraints within reazon--test-sudoku-solve-4x4.

### DIFF
--- a/reazon-sudoku.el
+++ b/reazon-sudoku.el
@@ -55,17 +55,13 @@ solved instances will be generated."
           coordinate-value-pairs)
 
        (reazon-subseto range `(,a1 ,a2 ,a3 ,a4))
-       (reazon-subseto range `(,a1 ,b1 ,c1 ,d1))
-       (reazon-subseto range `(,a1 ,a2 ,b1 ,b2))
        (reazon-subseto range `(,b1 ,b2 ,b3 ,b4))
+       (reazon-subseto range `(,c1 ,c2 ,c3 ,c4))
+       (reazon-subseto range `(,d1 ,d2 ,d3 ,d4))
+       (reazon-subseto range `(,a1 ,b1 ,c1 ,d1))
        (reazon-subseto range `(,a2 ,b2 ,c2 ,d2))
        (reazon-subseto range `(,a3 ,b3 ,c3 ,d3))
-       (reazon-subseto range `(,a3 ,a4 ,b3 ,b4))
-       (reazon-subseto range `(,a4 ,b4 ,c4 ,d4))
-       (reazon-subseto range `(,c1 ,c2 ,c3 ,c4))
-       (reazon-subseto range `(,c1 ,c2 ,d1 ,d2))
-       (reazon-subseto range `(,d1 ,d2 ,d3 ,d4))
-       (reazon-subseto range `(,c3 ,c4 ,d3 ,d4)))))
+       (reazon-subseto range `(,a4 ,b4 ,c4 ,d4)))))
 
 
 (defmacro reazon-sudoku-solve-9x9 (&rest coordinate-value-pairs)

--- a/reazon-tests.el
+++ b/reazon-tests.el
@@ -747,8 +747,10 @@
 
 (ert-deftest reazon--test-sudoku-solve-4x4 ()
   (reazon--should-equal '((2 3 1 4 4 1 3 2 3 2 4 1 1 4 2 3))
-    (reazon-sudoku-solve-4x4 (a2 3) (b1 4) (b4 2) (c4 1) (d3 2))))
+    (reazon-sudoku-solve-4x4 (a2 3) (b1 4) (b4 2) (c4 1) (d3 2)))
 
+  (reazon--should-equal '((1 2 3 4 4 1 2 3 3 4 1 2 2 3 4 1))
+    (reazon-sudoku-solve-4x4 (a1 1) (a2 2) (a3 3) (a4 4) (b1 4) (b4 3) (c4 2) (d3 4))))
 
 (provide 'reazon-tests)
 ;;; reazon-tests.el ends here


### PR DESCRIPTION
Super minor; it just needs the eight row and column constraints.