### PR TITLE
Error if reazon-defrel is run under dynamic scope

### DIFF
--- a/reazon.el
+++ b/reazon.el
@@ -425,10 +425,12 @@ Also known as committed choice. This operator is impure."
   "Define relation NAME with args VARLIST and body GOALS."
   (declare (indent 2))
   (let ((stream (gensym)))
-    `(defun ,name ,varlist
-       (lambda (,stream)
-         (lambda ()
-           (funcall (reazon-conj ,@goals) ,stream))))))
+    `(if (not lexical-binding)
+         (user-error "Can't define new relations when lexical binding is disabled!")
+       (defun ,name ,varlist
+         (lambda (,stream)
+           (lambda ()
+             (funcall (reazon-conj ,@goals) ,stream)))))))
 
 (reazon-defrel reazon-caro (p a)
   (reazon-fresh (d)

--- a/test/reazon-test-interface.el
+++ b/test/reazon-test-interface.el
@@ -120,6 +120,10 @@
   (reazon-disj (reazon-== x 'tea) (reazon-== x 'cup)))
 
 (ert-deftest reazon-test-interface-defrel ()
+  (should-error
+   (with-temp-buffer
+     (reazon-defrel reazon--test-dynamic-scopeo (x)))
+   :type 'user-error)
   (reazon--should-equal '(tea cup)
     (reazon-run* x (reazon--test-teacupo x)))
   (reazon--should-equal '((nil t) (tea t) (cup t))


### PR DESCRIPTION
explicitly alerts a user if their relation won't be defined properly

thanks for this cool project!
