### PR TITLE
Add `reazon-run-with-config` and 'timeout' option

### DIFF
--- a/test/reazon-test-interface.el
+++ b/test/reazon-test-interface.el
@@ -47,6 +47,21 @@
   (reazon--should-equal '(olive _0 oil)
     (reazon-run* x (reazon-disj (reazon-conj (reazon-== 'virgin x) #'reazon-!U) (reazon-disj (reazon-== 'olive x) (reazon-disj #'reazon-!S (reazon-== 'oil x)))))))
 
+(reazon-defrel reazon-test--alwayso ()
+  "Infinite successful goals."
+  (reazon-disj #'reazon-!S (reazon-test--alwayso)))
+
+(reazon-defrel reazon-test--nevero ()
+  "Infinite unsuccessful goals."
+  (reazon-disj #'reazon-!U (reazon-test--nevero)))
+
+(ert-deftest reazon-test-interface-timeout ()
+  (reazon--should-equal '()
+    (let ((reazon-timeout 0.01))
+      (reazon-run* q (reazon-test--nevero))))
+  ;; This test might fail if your computer is REALLY slow.
+  (should (> (length (let ((reazon-timeout 0.01)) (reazon-run* q (reazon-test--alwayso)))) 3)))
+
 (ert-deftest reazon-test-interface-fresh ()
   (reazon--should-equal '(t)
     (reazon-run* q


### PR DESCRIPTION
Hi again Nick,

As the title states this PR introduces a new run endpoint, `reazon-run-with-config`, and the current only config option is `:timeout`, which specifies what the maximum time a query can run for.

An `:check-occurs` config option could also be added later on to disable that feature for more performance.

My personal usecase for this is running reazon queries with an infinite search space interactively, where it either quickly succeeds or runs forever. Without this modification, you'd have to `C-g` out of every failed search.

Let me know if this looks OK!

