### PR TITLE
Fix bug with `reazon-defrel` and empty relations

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,9 +5,6 @@
 - Add flag for whether or not to run the occurs-check
 - Raise error on circular query
 
-** Bugs
-- A relation defined with no docstring or body will not work properly.
-
 * 0.3
 ** Added
 - The impure operators conda and condu

--- a/reazon.el
+++ b/reazon.el
@@ -458,10 +458,10 @@ Also known as committed choice. This operator is impure."
 
   ;; keep this nasty docstring logic
   ;; away from the relation definition
-  (if (stringp docstring)
-      (setq docstring `(,docstring))
-    (setq goals `(,docstring . ,goals)
-          docstring nil))
+  (cond
+   ((stringp docstring) (setq docstring `(,docstring)))
+   (docstring (setq goals `(,docstring . ,goals)
+                    docstring nil)))
 
   (let ((stream (gensym)))
     `(defun ,name ,varlist

--- a/test/reazon-test-interface.el
+++ b/test/reazon-test-interface.el
@@ -218,10 +218,7 @@
 
 (ert-deftest reazon-test-interface-empty-relation ()
   (reazon--should-equal '(_0)
-    (reazon-run* x (reazon--test-empty-relo-with-doc x))))
-
-(ert-deftest reazon-test-interface-empty-relation-fail ()
-  :expected-result :failed
+    (reazon-run* x (reazon--test-empty-relo-with-doc x)))
   (reazon--should-equal '(_0)
     (reazon-run* x (reazon--test-empty-relo x))))
 


### PR DESCRIPTION
If `docstring` and `body` were both nil, body would be set to `'(nil)`. Now `docstring` will only be cons'ed if non-nil.
