### PR TITLE
Remove unnecessary computation in reazon--take

### DIFF
--- a/reazon.el
+++ b/reazon.el
@@ -204,16 +204,17 @@ Should not be set manually; its value is derived from `reazon-timeout'.")
 If `stream' is a function, then `reazon--pull' ended due to a
 timeout, and the values collected so far will be returned."
   (declare (indent 1))
-  (if (or (functionp stream) (null stream))
-      nil
-    (let ((count (if n (1- n) -1))
-          (result (list (car stream)))
-          (rest (reazon--pull (cdr stream))))
-      (while (and rest (not (zerop count)) (not (functionp rest)))
-        (setq count (1- count))
-        (setq result (cons (car rest) result))
-        (setq rest (reazon--pull (cdr rest))))
-      (nreverse result))))
+  (cond
+   ((or (functionp stream) (null stream)) nil)
+   ((equal 1 n) (list (car stream)))
+   (t (let ((count (if n (1- n) -1))
+            (result (list (car stream)))
+            (rest (reazon--pull (cdr stream))))
+        (while (and rest (not (zerop count)) (not (functionp rest)))
+          (setq count (1- count))
+          (setq result (cons (car rest) result))
+          (setq rest (reazon--pull (cdr rest))))
+        (nreverse result)))))
 
 ;; -- Goals --
 

--- a/test/reazon-test-interface.el
+++ b/test/reazon-test-interface.el
@@ -27,6 +27,18 @@
 
 (require 'reazon-test-utils)
 
+(reazon-defrel reazon-test--alwayso ()
+  "Infinite successful goals."
+  (reazon-disj
+   #'reazon-!S
+   (reazon-test--alwayso)))
+
+(reazon-defrel reazon-test--nevero ()
+  "Infinite unsuccessful goals."
+  (reazon-disj
+   #'reazon-!U
+   (reazon-test--nevero)))
+
 (ert-deftest reazon-test-interface-run ()
   (reazon--should-equal '()
     (reazon-run* q
@@ -74,18 +86,6 @@
         (reazon-disj
          #'reazon-!S
          (reazon-== 'oil x)))))))
-
-(reazon-defrel reazon-test--alwayso ()
-  "Infinite successful goals."
-  (reazon-disj
-   #'reazon-!S
-   (reazon-test--alwayso)))
-
-(reazon-defrel reazon-test--nevero ()
-  "Infinite unsuccessful goals."
-  (reazon-disj
-   #'reazon-!U
-   (reazon-test--nevero)))
 
 (ert-deftest reazon-test-interface-timeout ()
   (reazon--should-equal '()

--- a/test/reazon-test-interface.el
+++ b/test/reazon-test-interface.el
@@ -85,7 +85,12 @@
         (reazon-== 'olive x)
         (reazon-disj
          #'reazon-!S
-         (reazon-== 'oil x)))))))
+         (reazon-== 'oil x))))))
+  (reazon--should-equal '(done)
+    (reazon-run 1 q
+      (reazon-disj
+       (reazon-== q 'done)
+       (reazon-test--nevero)))))
 
 (ert-deftest reazon-test-interface-timeout ()
   (reazon--should-equal '()


### PR DESCRIPTION
> In the case that `reazon-run` was set to generate 1 value,`reazon--take` would erroneously generate a second value and discard it.

Hey again!

I may have found a bug -- let me know what you think! If I'm not mistaken, would you mind rolling a `0.4.1` release for this? I think this could improve the performance of my package a fair bit, as I'm using a bunch of `(reazon-run 1 ...)`s around my codebase.